### PR TITLE
'uk' description to fix when found

### DIFF
--- a/common.descriptions.py
+++ b/common.descriptions.py
@@ -56,6 +56,7 @@ def main():
             'be': ['катэгарызацыя'], #https://www.wikidata.org/w/index.php?title=User:Emijrp/Wikimedia_project_pages_matrix&diff=next&oldid=500158307
             'be-tarask': ['Катэгорыя'],#https://www.wikidata.org/w/index.php?title=User:Emijrp/Wikimedia_project_pages_matrix&diff=next&oldid=500158307
             'es': ['categoría de Wikipedia'], 
+            'uk': ['Категорії'],
         }, 
         'Wikimedia disambiguation page': {
             'es': ['desambiguación de Wikipedia'], 

--- a/common.descriptions.py
+++ b/common.descriptions.py
@@ -111,6 +111,7 @@ def main():
             'nb': 'encyklopedisk artikkel',
             'nl': 'encyclopedisch artikel',
             'pl': 'artykuł w encyklopedii',
+            'ro': 'articol enciclopedic',
             'ru': 'энциклопедическая статья',
             'sl': 'enciklopedični članek',
             'sv': 'encyklopedisk artikel',


### PR DESCRIPTION
widespread wrong Ukrainian description ( = "Categories"); must be fixed when found.