### PR TITLE
bn fix

### DIFF
--- a/scientific.articles.py
+++ b/scientific.articles.py
@@ -35,7 +35,7 @@ def generateTranslations(pubdate=''):
         'ar': 'مقالة علمية',
         'ast': 'artículu científicu',
         'bg': 'научна статия',
-        #'bn': 'বৈজ্ঞানিক নিবন্ধ', #is plural?
+        'bn': 'বৈজ্ঞানিক নিবন্ধ',
         'ca': 'article científic',
         'cs': 'vědecký článek',
         'da': 'videnskabelig artikel',

--- a/scientific.articles.py
+++ b/scientific.articles.py
@@ -29,13 +29,14 @@ from wikidatafun import *
 
 def generateTranslations(pubdate=''):
     fixthiswhenfound = {
+        'bn': ['বৈজ্ঞানিক নিবন্ধ'],
         'es': ['artículo científico'], 
     }
     translations = {
         'ar': 'مقالة علمية',
         'ast': 'artículu científicu',
         'bg': 'научна статия',
-        'bn': 'বৈজ্ঞানিক নিবন্ধ',
+        'bn': '%s-এ প্রকাশিত বৈজ্ঞানিক নিবন্ধ' % (pubdate.year),
         'ca': 'article científic',
         'cs': 'vědecký článek',
         'da': 'videnskabelig artikel',


### PR DESCRIPTION
No, this isn't plural.

And is it possible to add something for translating "% (pubdate.year)" becasue bengali doesn't use latin word & number. something like this module https://bn.wikipedia.org/s/3d8 . If you can add that, then translation will be:

'bn': '%s % (pubdate.year)-এ প্রকাশিত বৈজ্ঞানিক নিবন্ধ',   

Question: what does «%s' % (pubdate.year)» means? see 'es'. 
Why there is a ' (Apostrophe) after %s. 
I guess (pubdate.year) should be year like 2007. Is «%s' %» means 'day' 'month'? 
So for Español «%s' % (pubdate.year)» means day' month year  eg. 24' Junio 2007  correct? I need to know for correct translation.

Thanks